### PR TITLE
Fix threading bugs

### DIFF
--- a/Exec/LyA/fcvode_extras.f90
+++ b/Exec/LyA/fcvode_extras.f90
@@ -8,7 +8,8 @@ module fcvode_extras
                               sunvec_y, yvec, T_out, ne_out, e_out)
 
         use amrex_fort_module, only : rt => amrex_real
-        use vode_aux_module, only: rho_vode, T_vode, ne_vode
+        use vode_aux_module, only: rho_vode, T_vode, ne_vode, z_vode
+        use atomic_rates_module, only: this_z
         use cvode_interface
         use fnvector_serial
         use, intrinsic :: iso_c_binding
@@ -33,6 +34,7 @@ module fcvode_extras
         T_vode   = T_in
         ne_vode  = ne_in
         rho_vode = rho_in
+        z_vode = this_z
 
         ! Initialize the integration time
         time = 0.d0

--- a/Exec/LyA/fcvode_extras.f90
+++ b/Exec/LyA/fcvode_extras.f90
@@ -34,7 +34,6 @@ module fcvode_extras
         T_vode   = T_in
         ne_vode  = ne_in
         rho_vode = rho_in
-        z_vode = this_z
 
         ! Initialize the integration time
         time = 0.d0

--- a/Exec/LyA/integrate_state_fcvode_3d.f90
+++ b/Exec/LyA/integrate_state_fcvode_3d.f90
@@ -39,7 +39,7 @@ subroutine integrate_state_fcvode(lo, hi, &
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_given_RT
     use fundamental_constants_module
     use comoving_module, only: comoving_h, comoving_OmB
-    use atomic_rates_module, only: tabulate_rates, interp_to_this_z, YHELIUM
+    use atomic_rates_module, only: tabulate_rates, YHELIUM
     use vode_aux_module    , only: z_vode, i_vode, j_vode, k_vode
     use cvode_interface
     use fnvector_serial
@@ -72,11 +72,7 @@ subroutine integrate_state_fcvode(lo, hi, &
 
     z = 1.d0/a - 1.d0
 
-    z_vode = z
     mean_rhob = comoving_OmB * 3.d0*(comoving_h*100.d0)**2 / (8.d0*M_PI*Gconst)
-
-    ! Interpolate from the table to this redshift
-    call interp_to_this_z(z)
 
     ! Note that (lo,hi) define the region of the box containing the grow cells
     ! Do *not* assume this is just the valid region

--- a/Exec/LyA/integrate_state_vode_3d.f90
+++ b/Exec/LyA/integrate_state_vode_3d.f90
@@ -58,7 +58,6 @@ subroutine integrate_state_vode(lo, hi, &
 
     z = 1.d0/a - 1.d0
 
-    z_vode = z
     mean_rhob = comoving_OmB * 3.d0*(comoving_h*100.d0)**2 / (8.d0*M_PI*Gconst)
 
     ! Note that (lo,hi) define the region of the box containing the grow cells

--- a/Exec/LyA/integrate_state_vode_3d.f90
+++ b/Exec/LyA/integrate_state_vode_3d.f90
@@ -38,7 +38,7 @@ subroutine integrate_state_vode(lo, hi, &
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_given_RT
     use fundamental_constants_module
     use comoving_module, only: comoving_h, comoving_OmB
-    use atomic_rates_module, only: tabulate_rates, interp_to_this_z, YHELIUM
+    use atomic_rates_module, only: tabulate_rates, YHELIUM
     use vode_aux_module    , only: z_vode, i_vode, j_vode, k_vode
 
     implicit none
@@ -60,9 +60,6 @@ subroutine integrate_state_vode(lo, hi, &
 
     z_vode = z
     mean_rhob = comoving_OmB * 3.d0*(comoving_h*100.d0)**2 / (8.d0*M_PI*Gconst)
-
-    ! Interpolate from the table to this redshift
-    call interp_to_this_z(z)
 
     ! Note that (lo,hi) define the region of the box containing the grow cells
     ! Do *not* assume this is just the valid region

--- a/Source/EOS/atomic_rates.f90
+++ b/Source/EOS/atomic_rates.f90
@@ -185,11 +185,14 @@ module atomic_rates_module
 
       subroutine fort_interp_to_this_z(z) bind(C, name='fort_interp_to_this_z')
 
+      use vode_aux_module, only: z_vode
+
       real(rt), intent(in) :: z
       real(rt) :: lopz, fact
       integer :: i, j
 
       this_z = z
+      z_vode = z
       lopz   = dlog10(1.0d0 + z)
 
       if (lopz .ge. lzr(NCOOLFILE)) then

--- a/Source/EOS/atomic_rates.f90
+++ b/Source/EOS/atomic_rates.f90
@@ -20,7 +20,7 @@ module atomic_rates_module
   implicit none
 
   ! Routine which acts like a class constructor
-  public  :: tabulate_rates, interp_to_this_z
+  public  :: tabulate_rates, fort_interp_to_this_z
 
   ! Photo- rates (from file)
   integer   , parameter          , private :: NCOOLFILE=301
@@ -183,7 +183,7 @@ module atomic_rates_module
 
       ! ****************************************************************************
 
-      subroutine interp_to_this_z(z) bind(C, name='interp_to_this_z')
+      subroutine fort_interp_to_this_z(z) bind(C, name='fort_interp_to_this_z')
 
       real(rt), intent(in) :: z
       real(rt) :: lopz, fact
@@ -222,6 +222,6 @@ module atomic_rates_module
       ehe0  = rehe0(j)  + (rehe0(j+1)-rehe0(j))*fact
       ehep  = rehep(j)  + (rehep(j+1)-rehep(j))*fact
 
-      end subroutine interp_to_this_z
+      end subroutine fort_interp_to_this_z
 
 end module atomic_rates_module

--- a/Source/EOS/atomic_rates.f90
+++ b/Source/EOS/atomic_rates.f90
@@ -225,23 +225,3 @@ module atomic_rates_module
       end subroutine interp_to_this_z
 
 end module atomic_rates_module
-
-! *************************************************************************************
-! This must live outside of atomic_rates module so it can be called by the C++
-! *************************************************************************************
-
-subroutine fort_init_this_z(comoving_a) &
-    bind(C, name="fort_init_this_z")
-
-    use amrex_fort_module, only : rt => amrex_real
-    use atomic_rates_module
-
-    implicit none
-
-    real(rt), intent(in   ) :: comoving_a
-    real(rt)                :: z
-
-    z = 1.d0/comoving_a - 1.d0
-    call interp_to_this_z(z)
-
-end subroutine fort_init_this_z

--- a/Source/EOS/atomic_rates.f90
+++ b/Source/EOS/atomic_rates.f90
@@ -183,7 +183,7 @@ module atomic_rates_module
 
       ! ****************************************************************************
 
-      subroutine interp_to_this_z(z)
+      subroutine interp_to_this_z(z) bind(C, name='interp_to_this_z')
 
       real(rt), intent(in) :: z
       real(rt) :: lopz, fact

--- a/Source/Forcing/ext_src_force_3d.f90
+++ b/Source/Forcing/ext_src_force_3d.f90
@@ -38,7 +38,6 @@ subroutine ext_src_force(lo, hi, old_state, os_l1, os_l2, os_l3, os_h1, os_h2, o
     use amrex_fort_module, only : rt => amrex_real
     use meth_params_module, only : NVAR, UMX, UMY, UMZ, UEDEN, UEINT
     use fundamental_constants_module
-    use atomic_rates_module, only: interp_to_this_z
 
     implicit none
 

--- a/Source/HeatCool/ext_src_hc_3d.f90
+++ b/Source/HeatCool/ext_src_hc_3d.f90
@@ -38,7 +38,6 @@ subroutine ext_src_hc(lo, hi, old_state, os_l1, os_l2, os_l3, os_h1, os_h2, os_h
     use amrex_fort_module, only : rt => amrex_real
     use meth_params_module, only : NVAR, UEDEN, UEINT, heat_cool_type
     use fundamental_constants_module
-    use atomic_rates_module, only: interp_to_this_z
 
     implicit none
 

--- a/Source/HeatCool/ext_src_hc_3d.f90
+++ b/Source/HeatCool/ext_src_hc_3d.f90
@@ -87,8 +87,6 @@ subroutine ext_src_hc(lo, hi, old_state, os_l1, os_l2, os_l3, os_h1, os_h2, os_h
     !      both "old_state" is in fact the "old" state and
     !           "new_state" is in fact the "new" state
 
-    call interp_to_this_z(z)
-
     half_dt = 0.5d0 * dt
     if (heat_cool_type .eq. 1) then
         call integrate_state_hc(lo,hi,tmp_state,ns_l1,ns_l2,ns_l3,ns_h1,ns_h2,ns_h3, &

--- a/Source/HeatCool/integrate_state_fcvode_3d_stubs.f90
+++ b/Source/HeatCool/integrate_state_fcvode_3d_stubs.f90
@@ -13,7 +13,7 @@ subroutine integrate_state_fcvode(lo, hi, &
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_given_RT
     use fundamental_constants_module
     use comoving_module, only: comoving_h, comoving_OmB
-    use atomic_rates_module, only: tabulate_rates, interp_to_this_z, YHELIUM
+    use atomic_rates_module, only: tabulate_rates, YHELIUM
     use vode_aux_module    , only: z_vode, i_vode, j_vode, k_vode, firstcall
 
     implicit none

--- a/Source/HeatCool/integrate_state_hc_3d.f90
+++ b/Source/HeatCool/integrate_state_hc_3d.f90
@@ -36,7 +36,7 @@ subroutine integrate_state_hc(lo, hi, &
     use network
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_given_RT
     use fundamental_constants_module
-    use atomic_rates_module, only: tabulate_rates, interp_to_this_z
+    use atomic_rates_module, only: tabulate_rates
     use heating_cooling_module, only: hc_rates
 
     implicit none
@@ -64,9 +64,6 @@ subroutine integrate_state_hc(lo, hi, &
     z = 1.d0/a - 1.d0
     do_diag   = .false.
     prnt_cell = .false.
-
-    ! Interpolate from the table to this redshift
-    call interp_to_this_z(z)
 
     b_fac = 0.0d0
     max_iter = 0

--- a/Source/HeatCool/integrate_state_vode_3d.f90
+++ b/Source/HeatCool/integrate_state_vode_3d.f90
@@ -36,7 +36,7 @@ subroutine integrate_state_vode(lo, hi, &
     use network
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_given_RT
     use fundamental_constants_module
-    use atomic_rates_module, only: tabulate_rates, interp_to_this_z
+    use atomic_rates_module, only: tabulate_rates
     use vode_aux_module    , only: z_vode, i_vode, j_vode, k_vode, T_vode
 
     implicit none
@@ -57,9 +57,6 @@ subroutine integrate_state_vode(lo, hi, &
     z = 1.d0/a - 1.d0
 
     z_vode = z
-
-    ! Interpolate from the table to this redshift
-    call interp_to_this_z(z)
 
     ! Note that (lo,hi) define the region of the box containing the grow cells
     ! Do *not* assume this is just the valid region

--- a/Source/HeatCool/integrate_state_vode_3d.f90
+++ b/Source/HeatCool/integrate_state_vode_3d.f90
@@ -56,8 +56,6 @@ subroutine integrate_state_vode(lo, hi, &
 
     z = 1.d0/a - 1.d0
 
-    z_vode = z
-
     ! Note that (lo,hi) define the region of the box containing the grow cells
     ! Do *not* assume this is just the valid region
     ! apply heating-cooling to UEDEN and UEINT

--- a/Source/Nyx.cpp
+++ b/Source/Nyx.cpp
@@ -565,7 +565,7 @@ Nyx::Nyx (Amr&            papa,
 
      // Initialize "this_z" in the atomic_rates_module
      if (heat_cool_type == 1 || heat_cool_type == 3 || heat_cool_type == 5)
-         fort_init_this_z(&old_a);
+         interp_to_this_z(&initial_z);
 
 #ifdef AGN
      // Initialize the uniform(0,1) random number generator.
@@ -2069,6 +2069,11 @@ Nyx::compute_new_temp ()
     reset_internal_energy(S_new,D_new);
 
     Real a = get_comoving_a(cur_time);
+
+    {
+      const Real z = 1.0/a - 1.0;
+      interp_to_this_z(&z);
+    }
 
 #ifdef _OPENMP
 #pragma omp parallel

--- a/Source/Nyx.cpp
+++ b/Source/Nyx.cpp
@@ -565,7 +565,7 @@ Nyx::Nyx (Amr&            papa,
 
      // Initialize "this_z" in the atomic_rates_module
      if (heat_cool_type == 1 || heat_cool_type == 3 || heat_cool_type == 5)
-         interp_to_this_z(&initial_z);
+         fort_interp_to_this_z(&initial_z);
 
 #ifdef AGN
      // Initialize the uniform(0,1) random number generator.
@@ -2072,7 +2072,7 @@ Nyx::compute_new_temp ()
 
     {
       const Real z = 1.0/a - 1.0;
-      interp_to_this_z(&z);
+      fort_interp_to_this_z(&z);
     }
 
 #ifdef _OPENMP

--- a/Source/Nyx_F.H
+++ b/Source/Nyx_F.H
@@ -246,11 +246,8 @@ extern "C"
      amrex::Real* comoving_a,
      const int* print_fortran_warnings);
 
-  void fort_init_this_z
-    (amrex::Real* comoving_a);
-
-  void fort_interp_to_this_z
-    (amrex::Real* z);
+  void interp_to_this_z
+    (const amrex::Real* z);
 
   void fort_compute_max_temp_loc
     (const int lo[], const int hi[],

--- a/Source/Nyx_F.H
+++ b/Source/Nyx_F.H
@@ -246,7 +246,7 @@ extern "C"
      amrex::Real* comoving_a,
      const int* print_fortran_warnings);
 
-  void interp_to_this_z
+  void fort_interp_to_this_z
     (const amrex::Real* z);
 
   void fort_compute_max_temp_loc

--- a/Source/Nyx_F.H
+++ b/Source/Nyx_F.H
@@ -249,6 +249,9 @@ extern "C"
   void fort_init_this_z
     (amrex::Real* comoving_a);
 
+  void fort_interp_to_this_z
+    (amrex::Real* z);
+
   void fort_compute_max_temp_loc
     (const int lo[], const int hi[],
      const BL_FORT_FAB_ARG(state),

--- a/Source/Nyx_hydro.cpp
+++ b/Source/Nyx_hydro.cpp
@@ -116,8 +116,8 @@ Nyx::just_the_hydro (Real time,
 
     BL_ASSERT(NUM_GROW == 4);
 
-    Real  e_added;
-    Real ke_added;
+    Real  e_added = 0;
+    Real ke_added = 0;
 
     // Create FAB for extended grid values (including boundaries) and fill.
     MultiFab S_old_tmp(S_old.boxArray(), S_old.DistributionMap(), NUM_STATE, NUM_GROW);

--- a/Source/Nyx_hydro.cpp
+++ b/Source/Nyx_hydro.cpp
@@ -134,8 +134,6 @@ Nyx::just_the_hydro (Real time,
        {
        FArrayBox flux[BL_SPACEDIM], u_gdnv[BL_SPACEDIM];
        Real cflLoc = -1.e+200;
-       e_added = 0.0;
-       ke_added = 0.0;
 
        for (MFIter mfi(S_old_tmp,true); mfi.isValid(); ++mfi)
        {

--- a/Source/Nyx_hydro.cpp
+++ b/Source/Nyx_hydro.cpp
@@ -116,8 +116,8 @@ Nyx::just_the_hydro (Real time,
 
     BL_ASSERT(NUM_GROW == 4);
 
-    Real  e_added = 0;
-    Real ke_added = 0;
+    Real  e_added;
+    Real ke_added;
 
     // Create FAB for extended grid values (including boundaries) and fill.
     MultiFab S_old_tmp(S_old.boxArray(), S_old.DistributionMap(), NUM_STATE, NUM_GROW);
@@ -129,11 +129,13 @@ Nyx::just_the_hydro (Real time,
         strang_first_step(time,dt,S_old_tmp,D_old_tmp);
 
 #ifdef _OPENMP
-#pragma omp parallel reduction(max:courno)
+#pragma omp parallel reduction(max:courno) reduction(+:e_added,ke_added)
 #endif
        {
        FArrayBox flux[BL_SPACEDIM], u_gdnv[BL_SPACEDIM];
        Real cflLoc = -1.e+200;
+       e_added = 0.0;
+       ke_added = 0.0;
 
        for (MFIter mfi(S_old_tmp,true); mfi.isValid(); ++mfi)
        {

--- a/Source/SourceTerms/Nyx_sources.cpp
+++ b/Source/SourceTerms/Nyx_sources.cpp
@@ -29,6 +29,8 @@ Nyx::get_old_source (Real      old_time,
     FillPatch(*this, Sborder, 4, old_time, State_Type, Density, Sborder.nComp());
     FillPatch(*this, Dborder, 4, old_time, DiagEOS_Type, 0, 2);
 
+    interp_to_this_z(&z);
+
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -86,6 +88,8 @@ Nyx::get_new_source (Real      old_time,
     FillPatch(*this, Sborder_new, 4, new_time, State_Type  , Density, Sborder_new.nComp());
     FillPatch(*this, Dborder_old, 4, old_time, DiagEOS_Type, 0      , 2);
     FillPatch(*this, Dborder_new, 4, new_time, DiagEOS_Type, 0      , 2);
+
+    interp_to_this_z(&z);
 
 #ifdef _OPENMP
 #pragma omp parallel

--- a/Source/SourceTerms/Nyx_sources.cpp
+++ b/Source/SourceTerms/Nyx_sources.cpp
@@ -29,7 +29,7 @@ Nyx::get_old_source (Real      old_time,
     FillPatch(*this, Sborder, 4, old_time, State_Type, Density, Sborder.nComp());
     FillPatch(*this, Dborder, 4, old_time, DiagEOS_Type, 0, 2);
 
-    interp_to_this_z(&z);
+    fort_interp_to_this_z(&z);
 
 #ifdef _OPENMP
 #pragma omp parallel
@@ -89,7 +89,7 @@ Nyx::get_new_source (Real      old_time,
     FillPatch(*this, Dborder_old, 4, old_time, DiagEOS_Type, 0      , 2);
     FillPatch(*this, Dborder_new, 4, new_time, DiagEOS_Type, 0      , 2);
 
-    interp_to_this_z(&z);
+    fort_interp_to_this_z(&z);
 
 #ifdef _OPENMP
 #pragma omp parallel

--- a/Source/Src_3d/compute_temp_3d.f90
+++ b/Source/Src_3d/compute_temp_3d.f90
@@ -9,7 +9,7 @@
 
       use amrex_fort_module, only : rt => amrex_real
       use eos_module
-      use atomic_rates_module, only: this_z, interp_to_this_z
+      use atomic_rates_module, only: this_z
       use meth_params_module, only : NVAR, URHO, UMX, UMY, UMZ, UEINT, UEDEN, &
                                      TEMP_COMP, NE_COMP, small_temp, heat_cool_type
       use  eos_params_module
@@ -29,11 +29,6 @@
       real(rt) :: z
 
       z = 1.d0/comoving_a - 1.d0
-
-      if (heat_cool_type.gt.0) then
-          if (z .ne. this_z) &
-             call interp_to_this_z(z)
-      end if
 
       do k = lo(3),hi(3)
          do j = lo(2),hi(2)

--- a/Source/comoving.cpp
+++ b/Source/comoving.cpp
@@ -231,8 +231,10 @@ Nyx::comoving_a_post_restart (const std::string& restart_file)
     }
 
      // Initialize "this_z" in the atomic_rates_module
-     if (heat_cool_type == 1 || heat_cool_type == 3 || heat_cool_type == 5)
-         fort_init_this_z(&old_a);
+     if (heat_cool_type == 1 || heat_cool_type == 3 || heat_cool_type == 5) {
+         Real old_z = 1.0/old_a - 1.0;
+         interp_to_this_z(&old_z);
+     }
 }
 
 void

--- a/Source/comoving.cpp
+++ b/Source/comoving.cpp
@@ -233,7 +233,7 @@ Nyx::comoving_a_post_restart (const std::string& restart_file)
      // Initialize "this_z" in the atomic_rates_module
      if (heat_cool_type == 1 || heat_cool_type == 3 || heat_cool_type == 5) {
          Real old_z = 1.0/old_a - 1.0;
-         interp_to_this_z(&old_z);
+         fort_interp_to_this_z(&old_z);
      }
 }
 

--- a/Source/strang_splitting.cpp
+++ b/Source/strang_splitting.cpp
@@ -16,7 +16,7 @@ Nyx::strang_first_step (Real time, Real dt, MultiFab& S_old, MultiFab& D_old)
 
     {
       const Real z = 1.0/a - 1.0;
-      interp_to_this_z(&z);
+      fort_interp_to_this_z(&z);
     }
 
 #ifdef _OPENMP
@@ -62,7 +62,7 @@ Nyx::strang_second_step (Real time, Real dt, MultiFab& S_new, MultiFab& D_new)
 
     {
       const Real z = 1.0/a - 1.0;
-      interp_to_this_z(&z);
+      fort_interp_to_this_z(&z);
     }
 
 #ifdef _OPENMP

--- a/Source/strang_splitting.cpp
+++ b/Source/strang_splitting.cpp
@@ -66,7 +66,7 @@ Nyx::strang_second_step (Real time, Real dt, MultiFab& S_new, MultiFab& D_new)
     }
 
 #ifdef _OPENMP
-#pragma omp parallel
+#pragma omp parallel private(min_iter_grid,max_iter_grid) reduction(min:min_iter) reduction(max:max_iter)
 #endif
     for (MFIter mfi(S_new,true); mfi.isValid(); ++mfi)
     {

--- a/Source/strang_splitting.cpp
+++ b/Source/strang_splitting.cpp
@@ -14,6 +14,11 @@ Nyx::strang_first_step (Real time, Real dt, MultiFab& S_old, MultiFab& D_old)
     const Real a = get_comoving_a(time);
     const Real* dx = geom.CellSize();
 
+    {
+      const Real z = 1.0/a - 1.0;
+      interp_to_this_z(&z);
+    }
+
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -54,6 +59,11 @@ Nyx::strang_second_step (Real time, Real dt, MultiFab& S_new, MultiFab& D_new)
     const Real* dx = geom.CellSize();
 
     compute_new_temp();
+
+    {
+      const Real z = 1.0/a - 1.0;
+      interp_to_this_z(&z);
+    }
 
 #ifdef _OPENMP
 #pragma omp parallel


### PR DESCRIPTION
There are several race conditions in Nyx, many related to updating atomic data inside OpenMP parallel regions. This series of commits removes most of them.