### PR TITLE
Remove OMP CRITICAL regions from Nyx

### DIFF
--- a/Exec/LyA/integrate_state_fcvode_3d.f90
+++ b/Exec/LyA/integrate_state_fcvode_3d.f90
@@ -39,7 +39,7 @@ subroutine integrate_state_fcvode(lo, hi, &
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_given_RT
     use fundamental_constants_module
     use comoving_module, only: comoving_h, comoving_OmB
-    use atomic_rates_module, only: tabulate_rates, YHELIUM
+    use atomic_rates_module, only: YHELIUM
     use vode_aux_module    , only: z_vode, i_vode, j_vode, k_vode
     use cvode_interface
     use fnvector_serial

--- a/Exec/LyA/integrate_state_fcvode_vec_3d.f90
+++ b/Exec/LyA/integrate_state_fcvode_vec_3d.f90
@@ -39,7 +39,7 @@ subroutine integrate_state_fcvode_vec(lo, hi, &
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_T_given_Re_vec, nyx_eos_given_RT
     use fundamental_constants_module
     use comoving_module, only: comoving_h, comoving_OmB
-    use atomic_rates_module, only: tabulate_rates, YHELIUM
+    use atomic_rates_module, only: YHELIUM
     use vode_aux_module    , only: z_vode, i_vode, j_vode, k_vode
     use cvode_interface
     use fnvector_serial

--- a/Exec/LyA/integrate_state_vode_3d.f90
+++ b/Exec/LyA/integrate_state_vode_3d.f90
@@ -38,7 +38,7 @@ subroutine integrate_state_vode(lo, hi, &
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_given_RT
     use fundamental_constants_module
     use comoving_module, only: comoving_h, comoving_OmB
-    use atomic_rates_module, only: tabulate_rates, YHELIUM
+    use atomic_rates_module, only: YHELIUM
     use vode_aux_module    , only: z_vode, i_vode, j_vode, k_vode
 
     implicit none

--- a/Source/EOS/atomic_rates.f90
+++ b/Source/EOS/atomic_rates.f90
@@ -19,9 +19,6 @@ module atomic_rates_module
 
   implicit none
 
-  ! Routine which acts like a class constructor
-  public  :: tabulate_rates, fort_interp_to_this_z
-
   ! Photo- rates (from file)
   integer   , parameter          , private :: NCOOLFILE=301
   real(rt), dimension(NCOOLFILE), public :: lzr
@@ -50,14 +47,13 @@ module atomic_rates_module
 
   contains
 
-      subroutine tabulate_rates()
+      subroutine fort_tabulate_rates() bind(C, name='fort_tabulate_rates')
       integer :: i
       logical, parameter :: Katz96=.false.
       real(rt), parameter :: t3=1.0d3, t5=1.0d5, t6=1.0d6
       real(rt) :: t, U, E, y, sqrt_t, corr_term
       logical, save :: first=.true.
 
-      !$OMP CRITICAL(TREECOOL_READ)
       if (first) then
 
          first = .false.
@@ -178,9 +174,8 @@ module atomic_rates_module
          endif  ! Katz rates
 
       end if  ! first_call
-      !$OMP END CRITICAL(TREECOOL_READ)
 
-      end subroutine tabulate_rates
+      end subroutine fort_tabulate_rates
 
       ! ****************************************************************************
 

--- a/Source/HeatCool/integrate_state_fcvode_3d_stubs.f90
+++ b/Source/HeatCool/integrate_state_fcvode_3d_stubs.f90
@@ -13,7 +13,7 @@ subroutine integrate_state_fcvode(lo, hi, &
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_given_RT
     use fundamental_constants_module
     use comoving_module, only: comoving_h, comoving_OmB
-    use atomic_rates_module, only: tabulate_rates, YHELIUM
+    use atomic_rates_module, only: YHELIUM
     use vode_aux_module    , only: z_vode, i_vode, j_vode, k_vode, firstcall
 
     implicit none

--- a/Source/HeatCool/integrate_state_fcvode_vec_3d_stubs.f90
+++ b/Source/HeatCool/integrate_state_fcvode_vec_3d_stubs.f90
@@ -13,7 +13,7 @@ subroutine integrate_state_fcvode_vec(lo, hi, &
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_given_RT
     use fundamental_constants_module
     use comoving_module, only: comoving_h, comoving_OmB
-    use atomic_rates_module, only: tabulate_rates, YHELIUM
+    use atomic_rates_module, only: YHELIUM
     use vode_aux_module    , only: z_vode, i_vode, j_vode, k_vode, firstcall
 
     implicit none

--- a/Source/HeatCool/integrate_state_hc_3d.f90
+++ b/Source/HeatCool/integrate_state_hc_3d.f90
@@ -36,7 +36,6 @@ subroutine integrate_state_hc(lo, hi, &
     use network
     use eos_module, only: nyx_eos_T_given_Re, nyx_eos_given_RT
     use fundamental_constants_module
-    use atomic_rates_module, only: tabulate_rates
     use heating_cooling_module, only: hc_rates
 
     implicit none

--- a/Source/Initialization/Nyx_setup.cpp
+++ b/Source/Initialization/Nyx_setup.cpp
@@ -235,6 +235,8 @@ Nyx::hydro_setup()
          use_const_species, gamma, normalize_species,
          heat_cool_type);
 
+    fort_tabulate_rates();
+
     if (use_const_species == 1)
         fort_set_eos_params(h_species, he_species);
 
@@ -650,6 +652,8 @@ Nyx::no_hydro_setup()
          use_colglaz, use_flattening, corner_coupling, version_2,
          use_const_species, gamma, normalize_species,
          heat_cool_type);
+
+    fort_tabulate_rates();
 
     int coord_type = Geometry::Coord();
     fort_set_problem_params(dm, phys_bc.lo(), phys_bc.hi(), Outflow, Symmetry, coord_type);

--- a/Source/Initialization/check_initial_species_3d.f90
+++ b/Source/Initialization/check_initial_species_3d.f90
@@ -7,6 +7,7 @@
       use  eos_params_module
 
       use amrex_fort_module, only : rt => amrex_real
+      use amrex_error_module, only : amrex_abort
       implicit none
 
       integer  :: lo(3), hi(3)
@@ -16,6 +17,7 @@
       ! Local variables
       integer  :: i,j,k,n
       real(rt) :: sum
+      character(len=256) :: errmsg_pt1, errmsg_pt2
 
       if (UFS .gt. 0) then
 
@@ -30,13 +32,11 @@
                    end do
 
                    if (abs(state(i,j,k,URHO)-sum).gt. 1.d-8 * state(i,j,k,URHO)) then
-                      !
-                      ! A critical region since we usually can't write from threads.
-                      !
-                      !$OMP CRITICAL
-                      print *,'Sum of (rho X)_i vs rho at (i,j,k): ',i,j,k,sum,state(i,j,k,URHO)
-                      call bl_error("Error:: Failed check of initial species summing to 1")
-                      !$OMP END CRITICAL
+                      write(errmsg_pt1, *) 'Sum of (rho X)_i vs rho at (i,j,k): ', &
+                        i,j,k,sum,state(i,j,k,URHO)
+                      write(errmsg_pt2, *) trim(errmsg_pt1) // new_line('a') // &
+                        'Failed check of initial species summing to 1'
+                      call amrex_abort(errmsg_pt2)
                    end if
     
                 enddo

--- a/Source/Nyx_F.H
+++ b/Source/Nyx_F.H
@@ -49,6 +49,8 @@ extern "C"
      const amrex::Real& gamma_in, const int& normalize_species,
      const int& heat_cool_type);
 
+  void fort_tabulate_rates();
+
   void filcc
     (const amrex::Real * q, ARLIM_P(q_lo), ARLIM_P(q_hi),
      const int * domlo, const int * domhi,

--- a/Source/Nyx_nd.f90
+++ b/Source/Nyx_nd.f90
@@ -357,10 +357,6 @@
 
         end if
 
-        if (heat_cool_type .eq. 1 .or. heat_cool_type .eq. 3 .or. heat_cool_type .eq. 5 .or. heat_cool_type .eq. 7) then
-           call tabulate_rates()
-        end if
-
         ! Easy indexing for the passively advected quantities.  
         ! This lets us loop over all four groups (advected, species, aux)
         ! in a single loop.


### PR DESCRIPTION
These commits remove the last remaining OMP CRITICAL regions in Nyx.