### PR TITLE
remove direct access of id and cpu, which will be removed from amrex

### DIFF
--- a/Exec/Henson/extract-particles/main.cpp
+++ b/Exec/Henson/extract-particles/main.cpp
@@ -20,7 +20,7 @@ int main()
         for (auto& kv : pmap) {
             const auto& pbx = kv.second.GetArrayOfStructs();
             for (const auto& p : pbx) {
-                if (p.m_idata.id > 0) {
+                if (p.id() > 0) {
                     // Load positions
                     for (int d=0; d < BL_SPACEDIM; d++)
                         locations.push_back(p.m_rdata.pos[d]);

--- a/Source/Particle/DarkMatterParticleContainer.cpp
+++ b/Source/Particle/DarkMatterParticleContainer.cpp
@@ -882,8 +882,8 @@ DarkMatterParticleContainer::InitFromBinaryMortonFile(const std::string& particl
         
         p.m_rdata.arr[BL_SPACEDIM] *= skip_factor;
         
-        p.m_idata.id  = ParticleType::NextID();
-        p.m_idata.cpu = ParallelDescriptor::MyProc();
+        p.id()  = ParticleType::NextID();
+        p.cpu() = ParallelDescriptor::MyProc();
         particles[std::make_pair(grid, tile)].push_back(p);
       }
     }    


### PR DESCRIPTION
These data members are currently implemented using an anonymous struct, which is not part of the C++ standard. They will be removed from amrex. You can still get and set them with `p.id()` and `p.cpu()`.  