### PR TITLE
update ascent ghost zone name

### DIFF
--- a/Source/IO/Nyx_output.cpp
+++ b/Source/IO/Nyx_output.cpp
@@ -1156,9 +1156,6 @@ Nyx::blueprint_check_point ()
 
     Ascent ascent;
     conduit::Node open_opts;
-    // tell ascent to use the ghost_indicator field to exclude ghosts
-
-    open_opts["ghost_field_name"] = "ghost_indicator";
     
 #ifdef BL_USE_MPI
     // if mpi, we need to provide the mpi comm to ascent


### PR DESCRIPTION
The ghost zone name in amrex has been updated to the ascent default name, so its no longer necessary to specify the field name.