### PR TITLE
CMake: few fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ cmake_dependent_option(Nyx_MPI_THREAD_MULTIPLE
 option(Nyx_SINGLE_PRECISION_PARTICLES
    "Use single precision particle data structures" YES )
 
-option( Nyx_HYDRO NO "Run with baryon hydro solve and fields")
+option( Nyx_HYDRO "Run with baryon hydro solve and fields" YES)
 cmake_dependent_option(Nyx_HEATCOOL "Run with H and He heating-cooling effects" NO
    "Nyx_HYDRO; NOT Nyx_GPU_BACKEND STREQUAL SYCL; NOT Nyx_GPU_BACKEND STREQUAL HIP" NO)
 
@@ -83,7 +83,7 @@ option( Nyx_REEBER             "" NO)
 
 #  These two are only really used by LyA_Neutrinos
 option( Nyx_NEUTRINO_PARTICLES "" NO)
-option( Nyx_NEUTRINO_DARK_PARTICLES "" no)
+option( Nyx_NEUTRINO_DARK_PARTICLES "" NO)
 
 
 #

--- a/Docs/sphinx_documentation/source/getting_started/BuildingCMake.rst
+++ b/Docs/sphinx_documentation/source/getting_started/BuildingCMake.rst
@@ -88,7 +88,7 @@ The CMake build process for Nyx is summarized as follows:
    | Nyx\_GPU\_      | On-node, accelerated GPU \   | NONE             | NONE,SYCL,\ |
    | BACKEND         | backend                      |                  | CUDA,HIP    |
    +-----------------+------------------------------+------------------+-------------+
-   | Nyx\_HYDRO      | Run with baryon hydro solve  | no/yes           | no          |
+   | Nyx\_HYDRO      | Run with baryon hydro solve  | no/yes           | yes         |
    |                 | and fields                   |                  |             |
    +-----------------+------------------------------+------------------+-------------+
    | Nyx\_HEATCOOL   | Run with H and He heating-   | no/yes           | no          |

--- a/Exec/CMakeLists.txt
+++ b/Exec/CMakeLists.txt
@@ -1,18 +1,21 @@
 include(NyxSetupExecutable)
 
 add_subdirectory(AMR-density)
-add_subdirectory(AMR-zoom)
+
 add_subdirectory(LyA)
 
 if (Nyx_HEATCOOL)
   # add_subdirectory(LyA_AGN)  # This is broken
 endif ()
 
-add_subdirectory(LyA_Neutrinos)
 
 if (Nyx_HYDRO)
+   add_subdirectory(AMR-zoom)
+   add_subdirectory(LyA_Neutrinos)
    add_subdirectory(HydroTests)
+   add_subdirectory(MiniSB)
    add_subdirectory(DrivenTurbulence)
+else()
+   message(WARNING "\nDisabling AMR-zoom, LyA_Neutrinos, HydroTests, MiniSB and DrivenTurbulence: "
+      "re-configure with -DNyx_HYDRO=YES to enable")
 endif ()
-
-add_subdirectory(MiniSB)

--- a/Exec/DrivenTurbulence/CMakeLists.txt
+++ b/Exec/DrivenTurbulence/CMakeLists.txt
@@ -1,9 +1,6 @@
 set(_sources     Prob.cpp Prob_error.cpp)
 set(_input_files inputs inputs.regtest)
 
-# Internal option for this test
-set(Nyx_FORCING  YES CACHE INTERNAL "")
-
 nyx_setup_executable(_sources _input_files)
 
 unset(_sources)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -45,10 +45,6 @@ if (Nyx_SDC)
    target_compile_definitions( nyxcore PUBLIC SDC)
 endif()
 
-if (Nyx_FORCING)
-   target_compile_definitions( nyxcore PUBLIC FORCING)
-endif ()
-
 if (Nyx_SUNDIALS)
    target_compile_definitions( nyxcore PUBLIC AMREX_USE_SUNDIALS)
 endif ()
@@ -93,9 +89,7 @@ add_subdirectory(DerivedQuantities)
 
 add_subdirectory(Driver)
 
-if (Nyx_FORCING)
-   add_subdirectory(Forcing)
-endif ()
+add_subdirectory(Forcing)
 
 if (Nyx_GRAVITY)
    add_subdirectory(Gravity)


### PR DESCRIPTION
   1) Get rid of Nyx_FORCING option (replaced by run-time option)
   2) Set Nyx_HYDRO=YES by default
   3) Better warnings when a directory in Exec are excluded from the build