### PR TITLE
Add runlog, JSON compile DB to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ UsersGuide/*.pdf
 \#*
 \.#*
 
+# JSON compilation database
+compile_commands.json
+
 # Mac:
 .DS_Store
 
@@ -49,6 +52,9 @@ ic_sb_32.ascii
 fixed_grids
 *est*-*
 *est.??????
+
+# logs
+runlog
 
 # build directories
 o/


### PR DESCRIPTION
1. The Nyx runlog seems like something we should ignore, given that we ignore other output files like `plt*`, `chk*`, and `Backtrace.*`
2. We already ignore files used by coding tools, e.g. emacs temporary files. Therefore it is reasonable to ignore a [JSON compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html). 
