### PR TITLE
runlog, tags, compile_commands.json in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,12 @@ UsersGuide/*.pdf
 \#*
 \.#*
 
+# JSON compilation database
+compile_commands.json
+
+# tag file
+tags
+
 # Mac:
 .DS_Store
 
@@ -49,6 +55,9 @@ ic_sb_32.ascii
 fixed_grids
 *est*-*
 *est.??????
+
+# logs
+runlog
 
 # build directories
 o/


### PR DESCRIPTION
Extended the `.gitignore` with some common files that should be ignored:
1. ctags file
2. [JSON compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) 
3. `runlog` file

1) and 2) are often generated during C++ development but usually are not tracked by version control. 3) is generated on each Nyx run.