### PR TITLE
Minor change

### DIFF
--- a/Exec/ParticleFilterTest/DarkMatterParticleContainer.cpp
+++ b/Exec/ParticleFilterTest/DarkMatterParticleContainer.cpp
@@ -731,7 +731,7 @@ void store_dm_particle_single (amrex::ParticleContainer<1+AMREX_SPACEDIM, 0>::Su
 
             Real xlen, ylen, zlen;
             //printf("Value is %d\n", maxind);
-	    int local_index=0;
+	    int local_index=-1;
         for(int idir=-maxind[0];idir<=maxind[0];idir++)
             for(int jdir=-maxind[1];jdir<=maxind[1];jdir++)
                 for(int kdir=-maxind[2];kdir<=maxind[2];kdir++)


### PR DESCRIPTION
This PR makes a minor change from @jmsexton03 that fixes the `plt` file writing for the lightcone shells on CPU. It has been verified that the number and position of the particles are the same for 1 CPU and 16 CPUs and same as the `csv` file that writes out the particles in a text format. 
Figure shows the z-velocity (km/s) contours on a lightcone shell at a red shift value of `z=49.49` and the computational domain.

![plt_light0004949](https://github.com/user-attachments/assets/ca4a5f3f-a59d-4403-8dfd-f6fc32013468)
