### PR TITLE
Fixed compile of in situ halo finding code.

### DIFF
--- a/Source/IO/Nyx_output.cpp
+++ b/Source/IO/Nyx_output.cpp
@@ -1086,7 +1086,7 @@ Nyx::updateInSitu ()
 #endif
 
 #ifdef REEBER
-    amrex::Vector<Halo>& reeber_halos);
+    amrex::Vector<Halo> reeber_halos;
     halo_find(parent->dtLevel(level), reeber_halos);
     halo_print(reeber_halos);
 #endif


### PR DESCRIPTION
Fixed in-situ halo finding code not compiling due a missing parenthesis, and trying to create a reference without initializing it. Runtime functionality (printing found halos to file) has been tested and appears to work.
