### PR TITLE
Reeber param input

### DIFF
--- a/Exec/LyA/inputs
+++ b/Exec/LyA/inputs
@@ -1,6 +1,9 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
 max_step = 10000000
 
+# use managed memory
+amrex.the_arena_is_managed=1
+
 nyx.ppm_type         = 1
 nyx.use_colglaz      = 0
 nyx.corner_coupling  = 1
@@ -140,12 +143,11 @@ nyx.plot_z_values   = 7.0 6.0 5.0 4.0 3.0 2.0
 amr.plot_vars        = density xmom ymom zmom rho_e Temp phi_grav
 amr.derive_plot_vars = particle_mass_density particle_count
 
-# Halo Finder
-#nyx.analysis_z_values = 150 10 5 4 3 2
-reeber.halo_int = 1
+# Halo finder
+reeber.min_halo_n_cells = 10
 reeber.negate = 1
-reeber.halo_density_vars = density particle_mass_density
-reeber.halo_extrema_threshold = 20
+#reeber.halo_density_vars = density particle_mass_density
+#reeber.halo_extrema_threshold = 20
 reeber.halo_component_threshold = 10
 #nyx.mass_halo_min = 1.e11
 #nyx.mass_seed = 1.e6

--- a/Source/Driver/Nyx.H
+++ b/Source/Driver/Nyx.H
@@ -996,6 +996,11 @@ protected:
   // Seed mass of SMBH
   //
   static amrex::Real mass_seed;
+
+  static int min_halo_n_cells;
+  static bool halo_negate;
+  static amrex::Real halo_component_threshold;
+
 #endif
 
   // Previous maximum number of steps for sundials

--- a/Source/Driver/Nyx.cpp
+++ b/Source/Driver/Nyx.cpp
@@ -204,6 +204,9 @@ Real Nyx::he_species        = 0.24;
 #ifdef REEBER
 Real Nyx::mass_halo_min     = 1.e10;
 Real Nyx::mass_seed         = 1.e5;
+Real Nyx::halo_component_threshold = 81.66;
+int Nyx::min_halo_n_cells = 10;
+bool Nyx::halo_negate = true;
 #endif
 
 #ifdef _OPENMP
@@ -445,6 +448,11 @@ Nyx::read_params ()
 #ifdef REEBER
     pp_nyx.query("mass_halo_min", mass_halo_min);
     pp_nyx.query("mass_seed", mass_seed);
+
+    ParmParse pp_reeber("reeber");
+    pp_reeber.query("min_halo_n_cells", min_halo_n_cells);
+    pp_reeber.query("halo_component_threshold", halo_component_threshold);
+    pp_reeber.query("negate", halo_negate);
 #endif
 }
 

--- a/Util/reeber/src/reeber.cpp
+++ b/Util/reeber/src/reeber.cpp
@@ -598,10 +598,7 @@ void Nyx::runReeberAnalysis(Vector<MultiFab*>& new_state,
 
     diy::DiscreteBounds diy_domain(3);
 
-    // TODO: take rho, min_halo_n_cells as parameters
-    Real min_halo_n_cells = 10;
-    Real rho = 81.66;
-
+    Real rho = halo_component_threshold;
     Real absolute_rho = (Nyx::average_dm_density + Nyx::average_gas_density) * rho;
     bool negate = true;  // sweep superlevel sets, highest density = root
     int finest_level = parent->finestLevel();


### PR DESCRIPTION
Add ability to pass `reeber.negate` and `reeber.halo_component_threshold` via input file. (Despite appearing in the documentation and in several input files, prior to this commit these values are not read by Nyx.) Also added ability to pass the minimum number of cells required for a region to be considered a halo (`reeber.min_halo_n_cells`). 