### PR TITLE
Remove the special overload of RedistributeGPU

### DIFF
--- a/Exec/ParticleFilterTest/NyxParticleContainer.H
+++ b/Exec/ParticleFilterTest/NyxParticleContainer.H
@@ -31,10 +31,6 @@ public:
                                     int lev_max              =-1,
                                     int nGrow                = 0) = 0;
 
-    virtual void RedistributeGPU   (int lev_min              = 0,
-                                    int lev_max              =-1,
-                                    int nGrow                = 0) = 0;
-
     virtual int finestLevel() const = 0;
     virtual void ShrinkToFit() = 0;
     virtual void RemoveParticlesAtLevel (int level) = 0;
@@ -149,29 +145,6 @@ public:
         amrex::NeighborParticleContainer<NSR,NSI>
             ::Redistribute(lev_min, lev_max, nGrow, local);
 
-    }
-
-    virtual void RedistributeGPU   (int /*lev_min              = 0*/,
-                                    int /*lev_max              =-1*/,
-                                    int /*nGrow                = 0*/) override
-    {
-        AMREX_ASSERT(this->finestLevel() == 0);
-
-        int local = false;
-        const int lev_minal = 0;
-        const int lev_maxal = 0;
-        const int nGrowal = 0;
-
-        amrex::Gpu::synchronize();
-        local =         amrex::NeighborParticleContainer<NSR,NSI>
-          ::OK(lev_minal, lev_maxal);
-        //      amrex::Print()<<"local flag is: "<<local<<std::endl;
-        if(local)
-        amrex::NeighborParticleContainer<NSR,NSI>
-            ::RedistributeGPU(lev_minal, lev_maxal, nGrowal, local);
-        else
-        amrex::NeighborParticleContainer<NSR,NSI>
-            ::RedistributeCPU(lev_minal, lev_maxal, nGrowal, local);
     }
 
     virtual void RemoveParticlesAtLevel (int level) override

--- a/Source/Particle/NyxParticleContainer.H
+++ b/Source/Particle/NyxParticleContainer.H
@@ -28,10 +28,6 @@ public:
                                     int lev_max              =-1,
                                     int nGrow                = 0) = 0;
 
-    virtual void RedistributeGPU   (int lev_min              = 0,
-                                    int lev_max              =-1,
-                                    int nGrow                = 0) = 0;
-
     virtual int finestLevel() const = 0;
     virtual void ShrinkToFit() = 0;
     virtual void RemoveParticlesAtLevel (int level) = 0;
@@ -146,29 +142,6 @@ public:
         amrex::NeighborParticleContainer<NSR,NSI>
             ::Redistribute(lev_min, lev_max, nGrow, local);
 
-    }
-
-    virtual void RedistributeGPU   (int /*lev_min              = 0*/,
-                                    int /*lev_max              =-1*/,
-                                    int /*nGrow                = 0*/) override
-    {
-        AMREX_ASSERT(this->finestLevel() == 0);
-
-        int local = false;
-        const int lev_minal = 0;
-        const int lev_maxal = 0;
-        const int nGrowal = 0;
-
-        amrex::Gpu::synchronize();
-        local =         amrex::NeighborParticleContainer<NSR,NSI>
-          ::OK(lev_minal, lev_maxal);
-        //      amrex::Print()<<"local flag is: "<<local<<std::endl;
-        if(local)
-        amrex::NeighborParticleContainer<NSR,NSI>
-            ::RedistributeGPU(lev_minal, lev_maxal, nGrowal, local);
-        else
-        amrex::NeighborParticleContainer<NSR,NSI>
-            ::RedistributeCPU(lev_minal, lev_maxal, nGrowal, local);
     }
 
     virtual void RemoveParticlesAtLevel (int level) override


### PR DESCRIPTION
This overload should not be necessary and, after [this](https://github.com/AMReX-Codes/amrex/pull/5268) to AMReX is merged, will not compile. This PR will need to be merged alongside the one in AMReX. 

Note that this does change the regtest answers slightly, but I think by an amount that is okay: https://ccse.lbl.gov/pub/RegressionTesting2/Nyx/2026-04-17-002/index.html